### PR TITLE
chore: remove formatter from nightly canary

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Run Noir tests
         run: nargo test
 
-      - name: Run formatter
-        run: nargo fmt --check
-
       - name: Alert on dead links
         uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3 

## Summary\*

This PR removes the formatter from the nightly canary to ensure that we get meaningful failures.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
