### PR TITLE
fix: bump `noir_sort` to `v0.2.3`

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [""]
 compiler_version = ">=0.36.0"
 
 [dependencies]
-sort = { tag = "v0.2.0", git = "https://github.com/noir-lang/noir_sort" }
+sort = { tag = "v0.2.3", git = "https://github.com/noir-lang/noir_sort" }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8 

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
